### PR TITLE
Copy Directory Support

### DIFF
--- a/panda_utils/assetpipeline/composer.py
+++ b/panda_utils/assetpipeline/composer.py
@@ -58,6 +58,20 @@ def load_from_file(filename, asset_markers=()):
             if pipeline is None:
                 continue
 
+            if tgt.copy_subdir != 0:
+                if abs(tgt.copy_subdir) > len(task.parts):
+                    raise ValueError(
+                        f"Copy_subdir value for: {folder} is greater then the dir depth found. Use a smaller number."
+                    )
+                # We set up so if we are negative we work up from our file
+                # If we are positive we work down from input
+                end = 0 if tgt.copy_subdir < 0 else tgt.copy_subdir + 1
+                start = tgt.copy_subdir if tgt.copy_subdir < 0 else 1
+
+                for i in range(start, end, 1):
+                    tgt.model_path += f"/{task.parts[i]}"
+                    tgt.texture_path += f"/{task.parts[i]}"
+
             pipeline = f"{PANDA_UTILS} {task} {tgt.model_path} {tgt.texture_path} {pipeline}"
             requires_commons = " cts" in pipeline
             target_model = BUILT_FOLDER / tgt.model_path / f"{task.name}.bam"

--- a/panda_utils/assetpipeline/composer.py
+++ b/panda_utils/assetpipeline/composer.py
@@ -68,16 +68,22 @@ def load_from_file(filename, asset_markers=()):
                 end = 0 if tgt.copy_subdir < 0 else tgt.copy_subdir + 1
                 start = tgt.copy_subdir if tgt.copy_subdir < 0 else 1
 
-                for i in range(start, end, 1):
-                    tgt.model_path += f"/{task.parts[i]}"
-                    tgt.texture_path += f"/{task.parts[i]}"
+                model_path = tgt.model_path
+                texture_path = tgt.texture_path
 
-            pipeline = f"{PANDA_UTILS} {task} {tgt.model_path} {tgt.texture_path} {pipeline}"
+                for i in range(start, end, 1):
+                    model_path += f"/{task.parts[i]}"
+                    texture_path += f"/{task.parts[i]}"
+            else:
+                model_path = tgt.model_path
+                texture_path = tgt.texture_path
+
+            pipeline = f"{PANDA_UTILS} {task} {model_path} {texture_path} {pipeline}"
             requires_commons = " cts" in pipeline
-            target_model = BUILT_FOLDER / tgt.model_path / f"{task.name}.bam"
+            target_model = BUILT_FOLDER / model_path / f"{task.name}.bam"
 
             rm_files = []
-            path = BUILT_FOLDER / tgt.texture_path
+            path = BUILT_FOLDER / texture_path
             if path.exists():
                 for file in os.listdir(path):
                     if file.startswith(task.name) and file_out_regex.match(file):

--- a/panda_utils/assetpipeline/composer.py
+++ b/panda_utils/assetpipeline/composer.py
@@ -59,14 +59,15 @@ def load_from_file(filename, asset_markers=()):
                 continue
 
             if tgt.copy_subdir != 0:
-                if abs(tgt.copy_subdir) > len(task.parts):
+                # We set up so if we are negative we work up from our file
+                # If we are positive we work down from input
+                end = 0 if tgt.copy_subdir < 0 else tgt.copy_subdir + 2
+                start = tgt.copy_subdir if tgt.copy_subdir < 0 else 2
+            
+                if max(abs(end), abs(start)) > len(task.parts):
                     raise ValueError(
                         f"Copy_subdir value for: {folder} is greater then the dir depth found. Use a smaller number."
                     )
-                # We set up so if we are negative we work up from our file
-                # If we are positive we work down from input
-                end = 0 if tgt.copy_subdir < 0 else tgt.copy_subdir + 1
-                start = tgt.copy_subdir if tgt.copy_subdir < 0 else 1
 
                 model_path = tgt.model_path
                 texture_path = tgt.texture_path

--- a/panda_utils/assetpipeline/target_parser.py
+++ b/panda_utils/assetpipeline/target_parser.py
@@ -131,6 +131,9 @@ class SingleTarget(BaseModel):
     texture_path: str
     """Where to put the texture after exporting? For example: phase_3/maps. Required."""
 
+    copy_subdir: int = 0
+    """Should we copy the directory structure as best we can?"""
+
     callback_type: CallbackType = CallbackType.STANDARD
     """Callback type. Currently supported: standard, actor, 2d palette."""
 

--- a/panda_utils/assetpipeline/target_parser.py
+++ b/panda_utils/assetpipeline/target_parser.py
@@ -132,7 +132,15 @@ class SingleTarget(BaseModel):
     """Where to put the texture after exporting? For example: phase_3/maps. Required."""
 
     copy_subdir: int = 0
-    """Should we copy the directory structure as best we can?"""
+    """
+    This value is used to control the subdirectory structure after building this input folder.
+    Positive values copy parts of the path starting from the input folder.
+    Negative values copy parts of the path starting from the input model.
+    For example, if the value is `+1` and the input file is located at input_folder/folderA/folderB/folderC/model.blend
+    the output model will be located at modelOutput/folderA/model.bam; if the value is `-1` the output model will be at
+    modelOutput/folderC/model.bam.
+    Defaults to 0, which causes all assets under `input_folder` to be put into the same folder modelOutput.
+    """
 
     callback_type: CallbackType = CallbackType.STANDARD
     """Callback type. Currently supported: standard, actor, 2d palette."""


### PR DESCRIPTION
Allows setting `copy_subdir` to copy the input's file structure up to a certain point. Setting it to a negative number copies the directory up from the target file location, setting the number positive works down from input. 