### PR TITLE
Composer: Use a list instead of relying on strict string splitting

### DIFF
--- a/panda_utils/assetpipeline/composer.py
+++ b/panda_utils/assetpipeline/composer.py
@@ -57,7 +57,7 @@ def load_from_file(filename, asset_markers=()):
             ctx = StepContext(os.listdir(task), tf.settings, tgt.import_method or tf.settings.default_import_method)
             # Contains the pipeline steps per yaml config
             pipeline_steps = make_pipeline(tgt, task.name, ctx)
-            if pipeline_steps is None:
+            if not pipeline_steps:
                 continue
 
             if tgt.copy_subdir != 0:
@@ -65,7 +65,7 @@ def load_from_file(filename, asset_markers=()):
                 # If we are positive we work down from input
                 end = 0 if tgt.copy_subdir < 0 else tgt.copy_subdir + 2
                 start = tgt.copy_subdir if tgt.copy_subdir < 0 else 2
-            
+
                 if max(abs(end), abs(start)) > len(task.parts):
                     raise ValueError(
                         f"Copy_subdir value for: {folder} is greater then the dir depth found. Use a smaller number."
@@ -86,9 +86,12 @@ def load_from_file(filename, asset_markers=()):
                 task,
                 model_path,
                 texture_path,
-                *pipeline_steps.split()
+                *pipeline_steps
             ]
-            requires_commons = " cts" in pipeline_steps  # Does this config require us to use common textures?
+
+            # Does this config require us to use common textures?
+            requires_commons = any([command.lower().startswith("cts:") for command in pipeline_steps])
+
             target_model = BUILT_FOLDER / model_path / f"{task.name}.bam"
 
             rm_files = []

--- a/panda_utils/assetpipeline/composer.py
+++ b/panda_utils/assetpipeline/composer.py
@@ -9,7 +9,7 @@ import yaml
 from panda_utils.assetpipeline.commons import BUILT_FOLDER, INPUT_FOLDER, file_out_regex, YAML_CONFIG_FILENAME
 from panda_utils.assetpipeline.target_parser import StepContext, TargetsFile, make_pipeline
 
-PANDA_UTILS = f"{sys.executable} -m panda_utils.assetpipeline"
+PANDA_UTILS = [sys.executable, '-m', 'panda_utils.assetpipeline']
 DOIT_CONFIG = {"default_tasks": ["build"]}
 ALL_FILES = []
 COMMON_TS = []
@@ -82,7 +82,7 @@ def load_from_file(filename, asset_markers=()):
                 texture_path = tgt.texture_path
 
             pipeline_args = [
-                PANDA_UTILS,
+                *PANDA_UTILS,
                 task,
                 model_path,
                 texture_path,

--- a/panda_utils/assetpipeline/target_parser.py
+++ b/panda_utils/assetpipeline/target_parser.py
@@ -2,7 +2,7 @@ import abc
 import dataclasses
 import os
 from enum import Enum
-from typing import Union
+from typing import Union, List
 
 from pydantic import BaseModel
 
@@ -344,7 +344,7 @@ def insert_extra_steps(pipeline: list[str], extra_steps):
             insert_extra_step(pipeline, name, value)
 
 
-def make_pipeline(target: SingleTarget, model_name: str, ctx: StepContext) -> Union[None, str]:
+def make_pipeline(target: SingleTarget, model_name: str, ctx: StepContext) -> List[str] | None:
     exporter_option = target.import_method
     if override := target.overrides.get(model_name):
         callback_type = override.callback_type or target.callback_type
@@ -385,4 +385,4 @@ def make_pipeline(target: SingleTarget, model_name: str, ctx: StepContext) -> Un
                 pipeline_blockout.append(value)
 
     insert_extra_steps(pipeline_blockout, extra_steps)
-    return " ".join(pipeline_blockout)
+    return pipeline_blockout


### PR DESCRIPTION
Fix crashes occuring from directories with spaces